### PR TITLE
fixed memo display bug

### DIFF
--- a/src/styles/components/memo.module.scss
+++ b/src/styles/components/memo.module.scss
@@ -184,6 +184,7 @@
   justify-content: center;
   align-items: center;
   width: 38px;
+  height: 51px;
   background-color: $memo-gray;
   border-radius: 2px;
   cursor: pointer;


### PR DESCRIPTION
By default, memo looks like this:

![image](https://user-images.githubusercontent.com/2721332/131754985-113fc032-aa35-4d53-befd-81ce9c70f721.png)

It seems the buttons are stretching to be really tall, making it so the icons aren't seen, and only the first two are visible. 

Setting a static height on the buttons fixes this and makes it so all buttons are properly visible and clickable.

![image](https://user-images.githubusercontent.com/2721332/131755163-555d65c2-ccb9-487f-8060-d7dadb2aef35.png)
